### PR TITLE
jsonpp: first pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/main
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,18 @@
+[root]
+name = "jsonpp"
+version = "0.0.1"
+dependencies = [
+ "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "argparse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+
+name = "jsonpp"
+version = "0.0.1"
+authors = [ "Jon Morehouse <morehousej09@gmail.com>" ]
+
+[dependencies]
+rustc-serialize = "0.3.16"
+argparse = "*"
+
+[[bin]]
+name = "jsonpp"
+path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# JSON Pretty Print
+> Yet another json pretty printer
+
+## Installation
+
+```bash
+$ git clone git@github.com:jonmorehouse/rust-jsonpp
+$ cd rust-jsonpp
+$ cargo build
+```
+
+## Basic Usage
+
+```bash
+$ echo '{"key": "value"}' | ./target/debug/jsonpp
+```
+
+```bash
+{
+  "key": "value"
+}
+```
+
+## Multiple Lines
+
+Some archive files embed many different json objects as single line, json strings. To prettify such json files, simple call `jsonpp` with the `-l` argument.
+
+```bash
+$ echo '{"key": "value"}\n{"key":"value"}' | ./target/debug/jsonpp -l
+```
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,54 @@
+extern crate rustc_serialize;
+use rustc_serialize::json::Json;
+
+extern crate argparse;
+use argparse::{ArgumentParser, StoreTrue};
+
+use std::process;
+use std::io::{self, Read};
+
+
+fn main() {
+    let mut lined = false;
+    {
+        let mut parser = ArgumentParser::new();
+        parser.set_description("JSON pretty printer");
+        parser.refer(&mut lined)
+            .add_option(&["-l", "--lined"], StoreTrue,
+            "Parse each line as its own JSON object");
+        parser.parse_args_or_exit();
+    }
+
+    
+    let mut stdin = io::stdin();
+    let mut json_buffer = &mut String::new();
+
+    match stdin.read_to_string(&mut json_buffer) {
+        Ok(_) => {},
+        Err(_) => {
+            println!("Unable to read from stdin");
+            process::exit(1);
+        },
+    }
+
+    {
+        let jsons: Vec<&str>;
+        if lined {
+            jsons = json_buffer.split_terminator('\n').collect();
+        } else {
+            jsons = vec![json_buffer];
+        }
+        
+        for json in jsons {
+            match Json::from_str(json) {
+                Ok(json) => {
+                    println!("{}", json.pretty());
+                },
+                Err(e) => {
+                    println!("Unable to parse json. Err: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding first pass at a json pretty printer in Rust. This supports both multiline json input as well.
